### PR TITLE
Proposed changes to mttp CSR

### DIFF
--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -21,9 +21,10 @@ an illegal instruction exception.
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits:  22, name: 'MTTPPN'},
-  {bits:  8, name: 'SDID'},
+  {bits:  6, name: 'SDID'},
+  {bits:  2, name: 'Zero'},
   {bits:  2, name: 'Mode'},
+  {bits:  22, name: 'MTTPPN'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 
@@ -33,9 +34,11 @@ an illegal instruction exception.
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits:  44, name: 'MTTPPN'},
-  {bits:  16, name: 'SDID'},
+  {bits:  6, name: 'SDID'},
+  {bits:  2, name: 'Zero'},
   {bits:  4, name: 'Mode'},
+  {bits:  44, name: 'MTTPPN'},
+  {bits:  8, name: 'Zero'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -21,10 +21,10 @@ an illegal instruction exception.
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits:  6, name: 'SDID'},
+  {bits:  2, name: 'Mode (WARL)'},
+  {bits:  6, name: 'SDID (WARL)'},
   {bits:  2, name: 'WPRI'},
-  {bits:  2, name: 'Mode'},
-  {bits:  22, name: 'PPN'},
+  {bits:  22, name: 'PPN (WARL)'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 
@@ -34,11 +34,10 @@ an illegal instruction exception.
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits:  6, name: 'SDID'},
-  {bits:  2, name: 'WPRI'},
-  {bits:  4, name: 'Mode'},
-  {bits:  44, name: 'PPN'},
-  {bits:  8, name: 'WPRI'},
+  {bits:  4, name: 'Mode (WARL)'},
+  {bits:  6, name: 'SDID (WARL)'},
+  {bits:  10, name: 'WPRI'},
+  {bits:  44, name: 'PPN (WARL)'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -22,9 +22,9 @@ an illegal instruction exception.
 ....
 {reg: [
   {bits:  6, name: 'SDID'},
-  {bits:  2, name: 'Zero'},
+  {bits:  2, name: 'WPRI'},
   {bits:  2, name: 'Mode'},
-  {bits:  22, name: 'MTTPPN'},
+  {bits:  22, name: 'PPN'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 
@@ -35,9 +35,9 @@ an illegal instruction exception.
 ....
 {reg: [
   {bits:  6, name: 'SDID'},
-  {bits:  2, name: 'Zero'},
+  {bits:  2, name: 'WPRI'},
   {bits:  4, name: 'Mode'},
-  {bits:  44, name: 'MTTPPN'},
+  {bits:  44, name: 'PPN'},
   {bits:  8, name: 'Zero'},
 ], config:{lanes: 1, hspace:1024}}
 ....

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -38,7 +38,7 @@ an illegal instruction exception.
   {bits:  2, name: 'WPRI'},
   {bits:  4, name: 'Mode'},
   {bits:  44, name: 'PPN'},
-  {bits:  8, name: 'Zero'},
+  {bits:  8, name: 'WPRI'},
 ], config:{lanes: 1, hspace:1024}}
 ....
 


### PR DESCRIPTION
proposed changes to mttp CSR to reserve upper bits for expanded PA (future), and reduce SDID to 6 bits and reserve remaining bits