### PR TITLE
Update IOMMU_ID and IOMTT SDID width to 8-bits

### DIFF
--- a/chapter6.adoc
+++ b/chapter6.adoc
@@ -307,8 +307,9 @@ operations requested through `control.OP`.
   {bits:  2, name: 'SRC_IDM (WARL)'},
   {bits:  2, name: 'TEE_FLT (WARL)'},
   {bits: 24, name: 'SRC_ID'},
-  {bits: 16, name: 'IOMMU_ID (WARL)'},
-  {bits: 16, name: 'SDID (WARL)'}
+  {bits:  8, name: 'IOMMU_ID (WARL)'},
+  {bits:  8, name: 'SDID (WARL)'},
+  {bits: 16, name: 'WPRI'}
 ], config:{lanes: 8, hspace:1024}}
 ....
 


### PR DESCRIPTION
Presently these were set as 16-bit identifiers. This PR sets the widths to more reasonable limits.