### PR TITLE
Updates to Smsdedbg per issue 21 and 26

### DIFF
--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -140,10 +140,8 @@ configuration for supervisor domains:
 
 . `Smsdia` uses `msdcfg.SDICN` to specify the active configuration for
   the supervisor domain interrupt controller associated with the hart.
-. External-debug-allowed state for a supervisor domain is managed via the
-  `msdcfg.sdedbgalw` bit.
-. External-trace-allowed state for a supervisor domain is managed via the
-  `msdcfg.sdetrcalw` bit.
+. `Smsdedbg` specifies the `msdcfg.sdedbgalw` bit to manage external-debug for a supervisor domain.
+. `Smsdetrc` specifies the `msdcfg.sdetrcalw` bit to manage external-trace for a supervisor domain.
 . `Smqosid` specifies the control bits `SSM`, `SRL`, `SML` and `SQRID` to enable
   the RDSM to manage QoS controls for supervisor domains.
 

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -134,12 +134,21 @@ after writing `mttp`.
 
 The `msdcfg` is a 32-bit read/write register, formatted as shown in <<MSDCFG>>.
 This CSR is used by M-mode software to specify the active configuration for
-capabilities of the supervisor domain when associated with a hart. The
-extension `Smsdia` uses `msdcfg.SDICN` to specify the active configuration for
-the supervisor domain interrupt controller associated with the hart. Similarly
-the external debug allowed state for a supervisor domain is controlled via the
-`msdcfg.SDEDBALW` bit. Details of `Smsdia` and `Smsdedbg` are described in
-their respective sections in this specification.
+capabilities of the supervisor domain when associated with a hart. +
+The following extensions use the `msdcfg` register to specify additional
+configuration for supervisor domains:
+
+. `Smsdia` uses `msdcfg.SDICN` to specify the active configuration for
+  the supervisor domain interrupt controller associated with the hart.
+. External-debug-allowed state for a supervisor domain is managed via the
+  `msdcfg.sdedbgalw` bit.
+. External-trace-allowed state for a supervisor domain is managed via the
+  `msdcfg.sdetrcalw` bit.
+. `Smqosid` specifies the control bits `SSM`, `SRL`, `SML` and `SQRID` to enable
+  the RDSM to manage QoS controls for supervisor domains.
+
+Details of `Smsdia`, `Smsdedbg`, `Smsdetrc` and `Smqosid` are described in their
+respective sections in this specification.
 
 [[MSDCFG]]
 .`msdcfg` register
@@ -148,8 +157,12 @@ their respective sections in this specification.
 ....
 {reg: [
   {bits:  6, name: 'SDICN'},
-  {bits:  1, name: 'WPRI'},
+  {bits:  1, name: 'SSM'},
   {bits:  1, name: 'SDEDBGALW'},
-  {bits: 25, name: 'WPRI'},
+  {bits:  1, name: 'SDETRCALW'},
+  {bits:  11, name: 'WPRI'},
+  {bits:  4, name: 'SRL'},
+  {bits:  4, name: 'SML'},
+  {bits:  4, name: 'SQRID'},
 ], config:{lanes: 4, hspace:1024}}
 ....

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -140,8 +140,10 @@ configuration for supervisor domains:
 
 . `Smsdia` uses `msdcfg.SDICN` to specify the active configuration for
   the supervisor domain interrupt controller associated with the hart.
-. `Smsdedbg` specifies the `msdcfg.sdedbgalw` bit to manage external-debug for a supervisor domain.
-. `Smsdetrc` specifies the `msdcfg.sdetrcalw` bit to manage external-trace for a supervisor domain.
+. `Smsdedbg` specifies the `msdcfg.sdedbgalw` bit to manage 
+  external-debug for a supervisor domain.
+. `Smsdetrc` specifies the `msdcfg.sdetrcalw` bit to manage 
+  external-trace for a supervisor domain.
 . `Smqosid` specifies the control bits `SSM`, `SRL`, `SML` and `SQRID` to enable
   the RDSM to manage QoS controls for supervisor domains.
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -118,7 +118,7 @@ The `metrcen` is an enable control for external trace for the `M-mode` driven by
 an external trace module and is expected to be established by the RoT (following
 RISC-V security model recommendations SR_GEN_007 and 012). When privilege is
 `M-mode`, the `metrcen` determines the state of the `halted` side band signal sent by the hart to the
-trace encoder. Per the Efficient trace specification cite:[Etrc], this side-band
+trace encoder. Per the Efficient trace specification cite:[ETrc], this side-band
 `halted` signal being asserted, stops subsequent tracing from the hart. On this
 signal being deasserted, the encoder can start tracing again.
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -6,22 +6,58 @@ The <<MSDCFG>> CSR contains the `sdedbgalw` bit that controls whether the
 current scheduled SD is allowed to be external-debugged. This bit is context
 switched (along with rest of the `msdcfg`) per SD.
 
+When M-mode external debug is enabled, all supervisor domains may also be
+debugged by an external debugger irrespective of the configuration held in
+`msdcfg.SDEDBGALW`.
+
+When M-mode external debug is disabled, whether execution at privilege modes
+less than `M-mode` may be debugged by an external debugger depends on the
+configuration held in `msdcfg.SDEDBGALW`.
+
+When `msdcfg.SDEDBGALW` = 0, external debug is disallowed. Abstract commands
+and halt request from the debug module are suppressed and stay pending.
+
+When `msdcfg.SDEDBGALW` = 1 then external debug of privilege modes less than
+`M-mode` is allowed, and:
+
+* A halt request may transition the hart to Debug Mode.
+* Abstract commands and program buffer execution can access state of privilege
+modes less than `M-mode`.
+* Read and Write of `Sdtrig` CSRs is allowed.
+* Debugger memory accesses occur with either `S-mode` or `U-mode` privilege (as
+if `aamvirtual` = 1 and `MPP` != `M-mode`).
+
 === `Smsdedbg` interaction with external debug security controls (Informative)
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
 [title= "External Debug for Supervisor Domain", id=Smsdedbg_img]
 image::images/Smsdedbg.png[]
 
-This section will be moved into the non-ISA specification for external debug
-security. It is described here as informational.
+This section will be moved into the specification for external debug security.
+It is described in this specification as informational.
 
 The `medbgen` is an enable control for external debug for the M-mode driven by
 the debug module and is expected to be established by the RoT (following RISC-V
 Security Model recommendation SR_GEN_007 and SR_GEN_012). When privilege is `M`,
 the `medbgen` gates the `haltreq` from the debug module and if is 0 prevents
-the hart from entering external debug mode. When privilege is less than `M`, the
-OR of the `MSDCFG.sdedbgalw` and `medbgen` gates the `haltreq` from the debug
-module and the hart will enter external debug mode if either is 1.
+the hart from entering external debug mode.
+
+The following change is proposed to behavior of `M-mode` access to triggers with
+`dmode` = 1. This change allows the RDSM to remain in control of external debug
+for supervisor domains (unless the RDSM is itself under external debug).
+
+When `medbgen` is 0 and privilege is `M-mode`:
+
+* M-mode can read and write triggers, *including triggers with `dmode` = 1
+without restrictions*.
+* Abstract commands and halt request from external debugger stay pending while
+privilege is `M-mode`.
+* All trigger-matching is suppressed (similar to how `MIE` or `MTE` would
+suppress them)
+
+When privilege is less than `M`, the OR of the `MSDCFG.sdedbgalw` and `medbgen`
+gates the `haltreq` from the debug module and the hart will enter external debug
+mode if either is 1.
 
 The configuration for `MSDCFG.sdedbgalw` may be obtained from the manifest/
 configuration of the supervisoer domain and should be managed by the M-mode root
@@ -30,8 +66,8 @@ security manager using secure memory.
 When `medbgen` is 1, there are no restrictions. When `medbgen` is 0 but
 `MSDCFG.sdedbgalw` is 1, then the external debug mode may be entered but is
 restricted by `M-mode` software to prevent privileged CSR accesses and memory
-accesses by instructions executed in external debug mode cannot use `M` privilege.
-When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, the M-mode root domain
-security manager must not configure triggers with `action=1`. Triggers for the
-supervisor domain are expected to be controlled by the root domain security
-manager to prevent any leakage of information.
+accesses by instructions executed in external debug mode cannot use `M-mode`
+privilege. When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, the `M-mode`
+root domain security manager must not configure triggers with `action=1`.
+Triggers for the supervisor domain are expected to be controlled by the root
+domain security manager to prevent any leakage of information.

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -73,7 +73,8 @@ accesses by instructions executed in Debug Mode cannot use `M-mode`
 privilege. When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, the `M-mode`
 root domain security manager must not configure triggers with `action=1`.
 Triggers for the supervisor domain must be controlled by the root
-domain security manager to prevent any leakage of information across security domains.
+domain security manager to prevent any leakage of information across security
+domains.
 
 === `Smsdetrc`: External Trace allowed control for Supervisor Domain
 
@@ -102,12 +103,27 @@ It is described in this specification as informational.
 The `metrcen` is an enable control for external trace for the `M-mode` driven by
 an external trace module and is expected to be established by the RoT (following
 RISC-V security model recommendations SR_GEN_007 and 012). When privilege is
-`M-mode`, the `metrcen` gates the `trTEActive` control into the hart trace
-encoder and if 0, prevents the hart from generating any trace output.
+`M-mode`, the `metrcen` gates the `halted` signal (from the hart) into the hart
+trace encoder. Per the specification <<R24>>, this side-band `halted` signal
+being asserted, prevents the hart from generating any trace output.
 
-When `metrcen` is 0 and privilege is `M-mode`, `M-mode` activity cannot be
-traced and `M-mode` software can enforce that `trTeEnable` is set to the state
-of `msdcfg.SDETRCALW` for the SD it context switches the hart into.
+[NOTE]
+====
+Implementation of the `halted` side-band signal is required to support external
+tracing with supervisor domains
+====
 
-When `metrcen` is 1, there are no restrictions and all privilege modes
-(inclusive of `M-mode` and any SDs managed by the RDSM) are traceable.
+When `metrcen` is 0:
+`halted` is asserted on:
+
+* entry to Debug mode
+* entry to `M-mode` privilege
+* entry to privilege less than `M-mode` with `msdcfg.SDETRCALW` = 0.
+
+and, `halted` is deasserted on entry to privilege less than `M-mode` with
+`msdcfg.SDETRCALW` = 0
+
+When `metrcen` is 1:
+There are no restrictions and all privilege modes (inclusive of `M-mode` and any
+SDs managed by the RDSM) are traceable. In this case, `halted` is asserted on
+entry to Debug mode, and deasserted on resumption from Debug Mode.

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -50,17 +50,17 @@ When `msdcfg.sdedbgalw` = 1 then external debug of privilege modes less than
 `M-mode` is allowed for such a supervisor domain on a per-hart basis, 
 with the additional requirements listed below. +
 
-To enforce the above controls specified by this extension, the following
-functional and security requirements must be met by the external secure debug
-system cite:[ExtDbgSec] to meet the security objectives of supervisor domain
-isolation:
-
-. External debug of M-mode can be enabled only by the HW RoT of the RDSM
- (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
 . External debug must be able to access supervisor domain memory and/or state. 
   In this context, "state" includes all supervisor domain resources accessible per the 
   Debug specification cite:[ExtDbg].
 . Entry to Debug Mode from a supervisor domain is allowed.
+
+To enforce the above controls specified by this extension, the following
+functional and security requirements must be met by the external secure debug
+system cite:[ExtDbgSec]:
+
+. External debug of M-mode can be enabled only by the HW RoT of the RDSM
+ (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
 . The RDSM must be able to context switch all triggers even when `d-mode` = 1.
   This functional change allows the RDSM to remain in control of external debug
   for supervisor domains when it is not under external debug itself.
@@ -81,10 +81,14 @@ When `msdcfg.sdetrcalw` = 1 then external trace of privilege modes less than
 `M-mode` shall be allowed for the SD on a per hart basis, with the
 additional requirements listed below.
 
+. When external tracing is disabled, tracing must be stopped on:
+.. entry to Debug mode
+.. entry to `M-mode` privilege
+.. entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0.
+
 To enforce the above controls specified by this extension, the following
-functional and security requirements must be met by the external secure debug
-system cite:[ExtDbgSec] to meet the security objectives of supervisor domain
-isolation:
+functional and security requirements must be met by the external debug security
+system cite:[ExtDbgSec]:
 
 . External trace of M-mode can be enabled only by the HW RoT of the RDSM
  (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -40,13 +40,11 @@ When M-mode external debug is disabled, whether execution at privilege modes
 less than `M-mode` may be debugged by an external debugger depends on the
 configuration held in `msdcfg.sdedbgalw`, as described below:
 
-When `msdcfg.sdedbgalw` = 0, external debug is disallowed for the supervisor
-domain. Abstract commands and halt request from the debug module are suppressed
-and stay pending while the supervisor domain is active, on a per-hart basis.
-Other debug operations (current or defined in the future) must similarly be kept
-pending while the supervisor domain is active on a hart. Triggers for the
-supervisor domain must be controlled by the RDSM to prevent any leakage of
-information across security domains.
+When `msdcfg.sdedbgalw` is 0:
+
+* Access by external debuggers to the memory and/or state of the supervisor domain is disallowed.
+* Entry to Debug Mode from a supervisor domain is disallowed.
+
 
 When `msdcfg.sdedbgalw` = 1 then external debug of privilege modes less than
 `M-mode` is allowed for such a supervisor domain on a per-hart basis. +
@@ -56,10 +54,8 @@ functional and security requirements must be met by the external secure debug
 system cite:[ExtDbgSec] to meet the security objectives of supervisor domain
 isolation:
 
-. The enable control for external debug driven by the external debug module is
-  expected to be established by the platform root-of-trust following RISC-V
-  Security Model recommendations SR_GEN_007 and SR_GEN_012. When the control is
-  in cleared state, the hart should not be able to enter external debug.
+. External debug of M-mode can be enabled only by the HW RoT of the RDSM
+ (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
 . External debug must be able to transition the hart to Debug Mode and access
   supervisor domain memory and state. In this context, "state" includes all
   non-M-mode resources accessible per the Debug specification cite:[ExtDbg].
@@ -68,14 +64,6 @@ isolation:
 . The RDSM must be able to context switch all triggers even when `d-mode` = 1.
   This functional change allows the RDSM to remain in control of external debug
   for supervisor domains when it is not under external debug itself.
-
-The following figure is non-normative and is intended to illustrate the use of
-the `msdcfg.sdedbgalw` control - the normative specification will be in the
-specification for external debug security cite:[ExtDbgSec].
-
-[caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title= "External Debug opt-in for Supervisor Domain", id=Smsdedbg_img]
-image::images/Smsdedbg.png[]
 
 === `Smsdetrc`: External Trace allowed control for Supervisor Domain
 
@@ -99,10 +87,8 @@ functional and security requirements must be met by the external secure debug
 system cite:[ExtDbgSec] to meet the security objectives of supervisor domain
 isolation:
 
-. The enable control for external trace driven by the external trace module is
-  expected to be established by the platform root-of-trust following RISC-V
-  Security Model recommendations SR_GEN_007 and SR_GEN_012. When the control is
-  in cleared state, the hart should not be able to generate trace.
+. External trace of M-mode can be enabled only by the HW RoT of the RDSM
+ (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
 . Per the Efficient trace specification cite:[ETrc], the side-band `halted`
   signal being asserted, stops subsequent tracing from the hart. On this signal
   being deasserted, the encoder can start tracing again. Implementation of this
@@ -118,7 +104,3 @@ isolation:
   `halted`) on:
 .. Entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0
 
-When external tracing is enabled (and authorized), there are no restrictions and
-all privilege modes (inclusive of `M-mode` and any supervisor domains managed by
-the RDSM) are traceable. In this case, tracing shall be enabled (via asserting
-`halted`) on entry to Debug mode, and stopped on resumption from Debug Mode.

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -56,11 +56,10 @@ isolation:
 
 . External debug of M-mode can be enabled only by the HW RoT of the RDSM
  (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
-. External debug must be able to transition the hart to Debug Mode and access
-  supervisor domain memory and state. In this context, "state" includes all
-  non-M-mode resources accessible per the Debug specification cite:[ExtDbg].
-. Triggers must match and fire on a hart only when a supervisor domain with this
-  configuration is active on a hart (and not in M-mode).
+. External debug must be able to access supervisor domain memory and/or state. 
+  In this context, "state" includes all supervisor domain resources accessible per the 
+  Debug specification cite:[ExtDbg].
+. Entry to Debug Mode from a supervisor domain is allowed.
 . The RDSM must be able to context switch all triggers even when `d-mode` = 1.
   This functional change allows the RDSM to remain in control of external debug
   for supervisor domains when it is not under external debug itself.
@@ -87,12 +86,10 @@ isolation:
 
 . External trace of M-mode can be enabled only by the HW RoT of the RDSM
  (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
-. When external tracing is disabled, tracing should be stopped (via asserting
-  `halted`) on:
+. When external tracing is disabled, tracing must be stopped on:
 .. entry to Debug mode
 .. entry to `M-mode` privilege
 .. entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0.
-. When extracing tracing is disabled, tracing should be started (via deasserting
-  `halted`) on:
-.. Entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0
+. When external tracing is disabled, tracing must be started on:
+.. Entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 1
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -75,9 +75,7 @@ When M-mode external trace is disabled, whether execution at privilege modes
 less than `M-mode` may be traced by an external trace tool depends on the
 configuration held in `msdcfg.sdetrcalw`, as described below:
 
-When `msdcfg.sdetrcalw` = 0, external trace is disallowed for the SD. All trace
-output from the trace encoder module are disabled while the SD is active on a
-per-hart basis.
+When `msdcfg.sdetrcalw` = 0, external trace of the supervisor domain is disallowed.
 
 When `msdcfg.sdetrcalw` = 1 then external trace of privilege modes less than
 `M-mode` shall be allowed for the SD on a per hart basis.
@@ -89,12 +87,6 @@ isolation:
 
 . External trace of M-mode can be enabled only by the HW RoT of the RDSM
  (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
-. Per the Efficient trace specification cite:[ETrc], the side-band `halted`
-  signal being asserted, stops subsequent tracing from the hart. On this signal
-  being deasserted, the encoder can start tracing again. Implementation of this
-  `halted` side-band signal is required to support external tracing with
-  supervisor domains. The state of the `halted` side-band signal shall be gated
-  by the external tracing enable control for M-mode.
 . When external tracing is disabled, tracing should be stopped (via asserting
   `halted`) on:
 .. entry to Debug mode

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -104,14 +104,17 @@ The `metrcen` is an enable control for external trace for the `M-mode` driven by
 an external trace module and is expected to be established by the RoT (following
 RISC-V security model recommendations SR_GEN_007 and 012). When privilege is
 `M-mode`, the `metrcen` gates the `halted` signal (from the hart) into the hart
-trace encoder. Per the specification <<R24>>, this side-band `halted` signal
-being asserted, prevents the hart from generating any trace output.
+trace encoder. Per the Efficient trace specification cite:[Etrc], this side-band
+`halted` signal being asserted, stops subsequent tracing from the hart. On this
+signal being deasserted, the encode can start tracing again.
 
 [NOTE]
 ====
 Implementation of the `halted` side-band signal is required to support external
 tracing with supervisor domains
 ====
+
+`Smsdetrc` specifies the following behavior for tracing with supervisor domains:
 
 When `metrcen` is 0:
 `halted` is asserted on:

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -9,6 +9,11 @@ software running on a separate target RISC-V platform, via a trace control/data
 transport that provides external access to the trace encoder controls
 cite:[ETrc]. This extension only affects debug or trace orchestrated by an
 external actor. Self-hosted debug (and trace) are managed by the RDSM.
+This sub-specification refers to the Debug specification cite:[ExtDbg],
+Trace specification cite:[ETrc], and the External debug security extension
+cite:[ExtDbgSec] for the description and behavior of controls outside
+the scope of this specification, but which interact with controls
+specified in this specification when supervisor domains are used.
 
 === `Smsdedbg`: External Debug allowed control for Supervisor Domain
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -39,7 +39,8 @@ modes less than `M-mode`. In this context, "state" includes all resources
 accessible per the Debug specification cite:[ExtDbg].
 * Read and Write of `Sdtrig` and `Sdext` CSRs are allowed.
 * Debugger memory accesses may occur with `S-mode` or `U-mode` privilege per
-software execution in the SD, and as if `aamvirtual` = 1 and `MPP` != `M-mode`.
+software execution in the SD, and as if `aamvirtual` = 1 and `MPP` != `M-mode`
+and `relaxedpriv`=0.
 
 ==== `Smsdedbg` interaction with external debug security controls (Informative)
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -27,7 +27,7 @@ When `msdcfg.SDEDBGALW` = 1 then external debug of privilege modes less than
 * A halt request may transition the hart to Debug Mode.
 * Abstract commands and program buffer execution can access state of privilege
 modes less than `M-mode`.
-* Read and Write of `Sdtrig` CSRs is allowed.
+* Read and Write of `Sdtrig` and `Sdext` CSRs are allowed.
 * Debugger memory accesses occur with either `S-mode` or `U-mode` privilege (as
 if `aamvirtual` = 1 and `MPP` != `M-mode`).
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -29,8 +29,11 @@ a hart.
 When `msdcfg.SDEDBGALW` = 1 then external debug of privilege modes less than
 `M-mode` is allowed for the SD on a per-hart basis, and:
 
-* A valid request e.g. `haltreq` may transition the hart to Debug Mode. See
-other cases in RISC-V Debug specification cite:[ExtDbg].
+* A valid request (e.g. `halt`) or a trigger matching/firing may transition the hart to
+Debug Mode. See other cases in RISC-V Debug specification cite:[ExtDbg]. 
+Note that the `resethaltreq` is not applicable since it can be done only
+following a reset and the hart cannot be at privilege mode less than
+`M-mode` with `msdcfg.SDEDBGALW`=1 at de-assertion of reset.
 * Abstract commands and program buffer execution can access state of privilege
 modes less than `M-mode`. In this context, "state" includes all resources
 accessible per the Debug specification cite:[ExtDbg].

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -69,7 +69,12 @@ without restrictions*.
 * Abstract commands and requests from an external debugger, that transition the
 hart into a halted state, stay pending while privilege is `M-mode` cite:[ExtDbg].
 * All trigger-matching is prevented from matching or firing, similar to how
-`MIE` or `MTE` would behave.
+`MIE` or `MTE` would behave. This behavior is specifically as stated in
+section 5.4 of cite:[ExtDbg]: While `MIE` in `mstatus` is 0, the hardware
+prevents triggers with `action`=0 from matching or firing while in `M-mode` .
+Also from section 5.7.6 of cite:[ExtDbg], M-mode trigger enable `mte`=0
+(disabled) specifies that triggers with `action`=0 do not match/fire
+while the hart is in M-mode.
 
 When privilege is less than `M`, the OR of the `MSDCFG.sdedbgalw` and `medbgen`
 gates the `haltreq` from the debug module and the hart will enter Debug

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -92,8 +92,3 @@ system cite:[ExtDbgSec]:
 
 . External trace of M-mode can be enabled only by the HW RoT of the RDSM
  (See RISC-V Security model requirements SR_GEN_007 and SR_GEN_012).
-. When external tracing is disabled, tracing must be stopped on:
-.. entry to Debug mode
-.. entry to `M-mode` privilege
-.. entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0.
-

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -92,6 +92,4 @@ isolation:
 .. entry to Debug mode
 .. entry to `M-mode` privilege
 .. entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0.
-. When external tracing is disabled, tracing must be started on:
-.. Entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 1
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -2,161 +2,123 @@
 [[Smsdedbg]]
 == Supervisor Domain External Trace and Debug
 
-The <<MSDCFG>> CSR contains the `sdedbgalw` and `sdetrcalw` bits that control
-if the current scheduled SD is allowed to be external-debugged or to be
-external-traced cite:[ExtDbg], respectively. External trace refers to tracing
-software running on a separate target RISC-V platform, via a trace control/data
-transport that provides external access to the trace encoder controls
-cite:[ETrc]. This extension only affects debug or trace orchestrated by an
-external actor. Self-hosted debug (and trace) are managed by the RDSM.
-This sub-specification refers to the Debug specification cite:[ExtDbg],
-Trace specification cite:[ETrc], and the External debug security extension
-cite:[ExtDbgSec] for the description and behavior of controls outside
-the scope of this specification, but which interact with controls
-specified in this specification when supervisor domains are used.
+This chapter describes two extensions `Smsdedbg` and `Smsdetrc` that enable a
+RDSM to manage isolation of supervisor domains when external debug and trace
+mechanisms are being utilized. `Smsdedbg` defines the `sdedbgalw` bit in the
+<<MSDCFG>> CSR that specifies if a supervisor domain is allowed to be
+externally-debugged. Similarly, `Smsdetrc` defines the `sdetrcalw` bit in the
+<<MSDCFG>> CSR that specifies if a supervisor domain is allowed to be
+externally-traced cite:[ExtDbg]. External trace refers to tracing software
+running on a separate target RISC-V platform, via a trace control/data transport
+that provides external access to the trace encoder controls cite:[ETrc]. These
+two extensions only affect debug and trace orchestrated by an external actor -
+self-hosted debug (and trace) are managed directly by the RDSM. This chapter
+refers to the Debug specification cite:[ExtDbg], Trace specification
+cite:[ETrc], and the External debug security extension cite:[ExtDbgSec] for the
+description and behavior of controls outside the scope of this specification,
+but which interact with controls specified in this specification when one or
+more supervisor domains are used. Note that `Smsdedbg` and `Smsdetrc` may be
+used as independent extensions even when a single supervisor domain is being
+utilized on a platform.
+
+[NOTE]
+====
+The configuration for `msdcfg.sdedbgalw` and `msdcfg.sdetrcalw` is expected to
+be obtained from the manifest/configuration of the supervisor domain and
+reported in the attestation report for the supervisor domain and it's workloads.
+The RDSM should manage this supervisor domain configuration state for context
+switching using secure memory.
+====
 
 === `Smsdedbg`: External Debug allowed control for Supervisor Domain
 
 When M-mode external debug is enabled, all supervisor domains may also be
 debugged by an external debugger irrespective of the configuration held in
-`msdcfg.SDEDBGALW`.
+`msdcfg.sdedbgalw`.
 
 When M-mode external debug is disabled, whether execution at privilege modes
 less than `M-mode` may be debugged by an external debugger depends on the
-configuration held in `msdcfg.SDEDBGALW`.
+configuration held in `msdcfg.sdedbgalw`, as described below:
 
-When `msdcfg.SDEDBGALW` = 0, external debug is disallowed for the SD. Abstract
-commands and halt request from the debug module are suppressed and stay pending
-while the SD is active, on a per-hart basis. Other debug operations (current or
-defined in the future) must similarly be kept pending while the SD is active on
-a hart.
+When `msdcfg.sdedbgalw` = 0, external debug is disallowed for the supervisor
+domain. Abstract commands and halt request from the debug module are suppressed
+and stay pending while the supervisor domain is active, on a per-hart basis.
+Other debug operations (current or defined in the future) must similarly be kept
+pending while the supervisor domain is active on a hart. Triggers for the
+supervisor domain must be controlled by the RDSM to prevent any leakage of
+information across security domains.
 
-When `msdcfg.SDEDBGALW` = 1 then external debug of privilege modes less than
-`M-mode` is allowed for the SD on a per-hart basis, and:
+When `msdcfg.sdedbgalw` = 1 then external debug of privilege modes less than
+`M-mode` is allowed for such a supervisor domain on a per-hart basis. +
 
-* A valid request (e.g. `halt`) or a trigger matching/firing may transition the hart to
-Debug Mode. See other cases in RISC-V Debug specification cite:[ExtDbg]. 
-Note that the `resethaltreq` is not applicable since it can be done only
-following a reset and the hart cannot be at privilege mode less than
-`M-mode` with `msdcfg.SDEDBGALW`=1 at de-assertion of reset.
-* Abstract commands and program buffer execution can access state of privilege
-modes less than `M-mode`. In this context, "state" includes all resources
-accessible per the Debug specification cite:[ExtDbg].
-* Read and Write of `Sdtrig` and `Sdext` CSRs are allowed.
-* Debugger memory accesses may occur with `S-mode` or `U-mode` privilege per
-software execution in the SD, and as if `aamvirtual` = 1 and `MPP` != `M-mode`
-and `relaxedpriv`=0.
+To enforce the above controls specified by this extension, the following
+functional and security requirements must be met by the external secure debug
+system cite:[ExtDbgSec] to meet the security objectives of supervisor domain
+isolation:
 
-==== `Smsdedbg` interaction with external debug security controls (Informative)
+. The enable control for external debug driven by the external debug module is
+  expected to be established by the platform root-of-trust following RISC-V
+  Security Model recommendations SR_GEN_007 and SR_GEN_012. When the control is
+  in cleared state, the hart should not be able to enter external debug.
+. External debug must be able to transition the hart to Debug Mode and access
+  supervisor domain memory and state. In this context, "state" includes all
+  non-M-mode resources accessible per the Debug specification cite:[ExtDbg].
+. Triggers must match and fire on a hart only when a supervisor domain with this
+  configuration is active on a hart (and not in M-mode).
+. The RDSM must be able to context switch all triggers even when `d-mode` = 1.
+  This functional change allows the RDSM to remain in control of external debug
+  for supervisor domains when it is not under external debug itself.
 
-This section will be moved into the specification for external debug security.
-It is described in this specification as informational.
-
+The following figure is non-normative and is intended to illustrate the use of
+the `msdcfg.sdedbgalw` control - the normative specification will be in the
+specification for external debug security cite:[ExtDbgSec].
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title= "External Debug for Supervisor Domain", id=Smsdedbg_img]
+[title= "External Debug opt-in for Supervisor Domain", id=Smsdedbg_img]
 image::images/Smsdedbg.png[]
-
-
-The `medbgen` is an enable control for external debug for the M-mode driven by
-the debug module and is expected to be established by the RoT (following RISC-V
-Security Model recommendation SR_GEN_007 and SR_GEN_012). When privilege is `M`,
-the `medbgen` gates the `haltreq` from the debug module and if is 0 prevents
-the hart from entering external debug mode.
-
-The following change is proposed to behavior of `M-mode` access to triggers with
-`dmode` = 1. This change allows the RDSM to remain in control of external debug
-for supervisor domains (unless the RDSM is itself under external debug in which
-case this relaxation is a don't care condition).
-
-When `medbgen` is 0 and privilege is `M-mode`:
-
-* M-mode can read and write triggers, *including triggers with `dmode` = 1
-without restrictions*.
-* Abstract commands and requests from an external debugger, that transition the
-hart into a halted state, stay pending while privilege is `M-mode` cite:[ExtDbg].
-* All trigger-matching is prevented from matching or firing, similar to how
-`MIE` or `MTE` would behave. This behavior is specifically as stated in
-section 5.4 of cite:[ExtDbg]: While `MIE` in `mstatus` is 0, the hardware
-prevents triggers with `action`=0 from matching or firing while in `M-mode` .
-Also from section 5.7.6 of cite:[ExtDbg], M-mode trigger enable `mte`=0
-(disabled) specifies that triggers with `action`=0 do not match/fire
-while the hart is in M-mode.
-
-When privilege is less than `M`, the OR of the `MSDCFG.sdedbgalw` and `medbgen`
-gates the `haltreq` from the debug module and the hart will enter Debug
-Mode if either is 1.
-
-[NOTE]
-====
-The configuration for `MSDCFG.sdedbgalw` may be obtained from the manifest/
-configuration of the supervisor domain and should be managed by the M-mode root
-security manager using secure memory.
-====
-
-When `medbgen` is 1, there are no restrictions on external debug added by this
-specification.
-
-When `medbgen` is 0 but `MSDCFG.sdedbgalw` is 1, then the external debug mode
-may be entered but may be restricted by `M-mode` software by the setting of the
-`MSDCFG.sdedbgalw` control to prevent privileged CSR accesses, memory accesses
-by instructions executed, abstract commands in Debug Mode cannot use `M-mode`
-privilege.
-
-When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, triggers for the
-supervisor domain must be controlled by the root domain security manager to
-prevent any leakage of information across security domains. For example, RDSM
-should enforce triggers are programmed with `mcontrol.m` bit clear.
 
 === `Smsdetrc`: External Trace allowed control for Supervisor Domain
 
 When M-mode external trace is enabled, all supervisor domains activity may also
 be traced by an external trace tool irrespective of the configuration held in
-`msdcfg.SDETRCALW`.
+`msdcfg.sdetralw`.
 
 When M-mode external trace is disabled, whether execution at privilege modes
 less than `M-mode` may be traced by an external trace tool depends on the
-configuration held in `msdcfg.SDETRCALW`.
+configuration held in `msdcfg.sdetrcalw`, as described below:
 
-When `msdcfg.SDETRCALW` = 0, external trace is disallowed for the SD. All trace
+When `msdcfg.sdetrcalw` = 0, external trace is disallowed for the SD. All trace
 output from the trace encoder module are disabled while the SD is active on a
 per-hart basis.
 
-When `msdcfg.SDETRCALW` = 1 then external trace of privilege modes less than
+When `msdcfg.sdetrcalw` = 1 then external trace of privilege modes less than
 `M-mode` shall be allowed for the SD on a per hart basis.
 
-==== `Smsdetrc`: interaction with external trace security controls (Informative)
+To enforce the above controls specified by this extension, the following
+functional and security requirements must be met by the external secure debug
+system cite:[ExtDbgSec] to meet the security objectives of supervisor domain
+isolation:
 
-This section will be moved into the specification for external debug security.
-It is described in this specification as informational.
+. The enable control for external trace driven by the external trace module is
+  expected to be established by the platform root-of-trust following RISC-V
+  Security Model recommendations SR_GEN_007 and SR_GEN_012. When the control is
+  in cleared state, the hart should not be able to generate trace.
+. Per the Efficient trace specification cite:[ETrc], the side-band `halted`
+  signal being asserted, stops subsequent tracing from the hart. On this signal
+  being deasserted, the encoder can start tracing again. Implementation of this
+  `halted` side-band signal is required to support external tracing with
+  supervisor domains. The state of the `halted` side-band signal shall be gated
+  by the external tracing enable control for M-mode.
+. When external tracing is disabled, tracing should be stopped (via asserting
+  `halted`) on:
+.. entry to Debug mode
+.. entry to `M-mode` privilege
+.. entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0.
+. When extracing tracing is disabled, tracing should be started (via deasserting
+  `halted`) on:
+.. Entry to privilege less than `M-mode` with `msdcfg.sdetrcalw` = 0
 
-The `metrcen` is an enable control for external trace for the `M-mode` driven by
-an external trace module and is expected to be established by the RoT (following
-RISC-V security model recommendations SR_GEN_007 and 012). When privilege is
-`M-mode`, the `metrcen` determines the state of the `halted` side band signal sent by the hart to the
-trace encoder. Per the Efficient trace specification cite:[ETrc], this side-band
-`halted` signal being asserted, stops subsequent tracing from the hart. On this
-signal being deasserted, the encoder can start tracing again.
-
-[NOTE]
-====
-Implementation of the `halted` side-band signal is required to support external
-tracing with supervisor domains
-====
-
-`Smsdetrc` specifies the following behavior for tracing with supervisor domains:
-
-When `metrcen` is 0:
-`halted` is asserted on:
-
-* entry to Debug mode
-* entry to `M-mode` privilege
-* entry to privilege less than `M-mode` with `msdcfg.SDETRCALW` = 0.
-
-and, `halted` is deasserted on entry to privilege less than `M-mode` with
-`msdcfg.SDETRCALW` = 0
-
-When `metrcen` is 1:
-There are no restrictions and all privilege modes (inclusive of `M-mode` and any
-SDs managed by the RDSM) are traceable. In this case, `halted` is asserted on
-entry to Debug mode, and deasserted on resumption from Debug Mode.
+When external tracing is enabled (and authorized), there are no restrictions and
+all privilege modes (inclusive of `M-mode` and any supervisor domains managed by
+the RDSM) are traceable. In this case, tracing shall be enabled (via asserting
+`halted`) on entry to Debug mode, and stopped on resumption from Debug Mode.

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -49,12 +49,14 @@ and `relaxedpriv`=0.
 
 ==== `Smsdedbg` interaction with external debug security controls (Informative)
 
+This section will be moved into the specification for external debug security.
+It is described in this specification as informational.
+
+
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
 [title= "External Debug for Supervisor Domain", id=Smsdedbg_img]
 image::images/Smsdedbg.png[]
 
-This section will be moved into the specification for external debug security.
-It is described in this specification as informational.
 
 The `medbgen` is an enable control for external debug for the M-mode driven by
 the debug module and is expected to be established by the RoT (following RISC-V

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -106,7 +106,7 @@ When `msdcfg.SDETRCALW` = 0, external trace is disallowed for the SD. All trace
 output from the trace encoder module are disabled while the SD is active on a
 per-hart basis.
 
-When `msdcfg.SDEDBGALW` = 1 then external trace of privilege modes less than
+When `msdcfg.SDETRCALW` = 1 then external trace of privilege modes less than
 `M-mode` shall be allowed for the SD on a per hart basis.
 
 ==== `Smsdetrc`: interaction with external trace security controls (Informative)

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -4,8 +4,7 @@
 
 The <<MSDCFG>> CSR contains the `sdedbgalw` and `sdetrcalw` bits that control
 whether the current scheduled SD is allowed to be external-debugged or to be
-external-traced (independently). These control bits are context switched (as
-part of the `msdcfg`) per SD.
+external-traced respectively.
 
 === `Smsdedbg`: External Debug allowed control for Supervisor Domain
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -1,10 +1,13 @@
 [[chapter8]]
 [[Smsdedbg]]
-== `Smsdedbg`: Supervisor Domain External Debug
+== Supervisor Domain External Trace and Debug
 
-The <<MSDCFG>> CSR contains the `sdedbgalw` bit that controls whether the
-current scheduled SD is allowed to be external-debugged. This bit is context
-switched (along with rest of the `msdcfg`) per SD.
+The <<MSDCFG>> CSR contains the `sdedbgalw` and `sdetrcalw` bits that control
+whether the current scheduled SD is allowed to be external-debugged or to be
+external-traced (independently). These control bits are context switched (as
+part of the `msdcfg`) per SD.
+
+=== `Smsdedbg`: External Debug allowed control for Supervisor Domain
 
 When M-mode external debug is enabled, all supervisor domains may also be
 debugged by an external debugger irrespective of the configuration held in
@@ -14,11 +17,12 @@ When M-mode external debug is disabled, whether execution at privilege modes
 less than `M-mode` may be debugged by an external debugger depends on the
 configuration held in `msdcfg.SDEDBGALW`.
 
-When `msdcfg.SDEDBGALW` = 0, external debug is disallowed. Abstract commands
-and halt request from the debug module are suppressed and stay pending.
+When `msdcfg.SDEDBGALW` = 0, external debug is disallowed for the SD. Abstract
+commands and halt request from the debug module are suppressed and stay pending
+while the SD is active.
 
 When `msdcfg.SDEDBGALW` = 1 then external debug of privilege modes less than
-`M-mode` is allowed, and:
+`M-mode` is allowed for the SD, and:
 
 * A halt request may transition the hart to Debug Mode.
 * Abstract commands and program buffer execution can access state of privilege
@@ -27,7 +31,7 @@ modes less than `M-mode`.
 * Debugger memory accesses occur with either `S-mode` or `U-mode` privilege (as
 if `aamvirtual` = 1 and `MPP` != `M-mode`).
 
-=== `Smsdedbg` interaction with external debug security controls (Informative)
+==== `Smsdedbg` interaction with external debug security controls (Informative)
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
 [title= "External Debug for Supervisor Domain", id=Smsdedbg_img]
@@ -71,3 +75,40 @@ privilege. When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, the `M-mode`
 root domain security manager must not configure triggers with `action=1`.
 Triggers for the supervisor domain are expected to be controlled by the root
 domain security manager to prevent any leakage of information.
+
+=== `Smsdetrc`: External Trace allowed control for Supervisor Domain
+
+When M-mode external trace is enabled, all supervisor domains activity may also
+be traced by an external debugger irrespective of the configuration held in
+`msdcfg.SDETRCALW`.
+
+When M-mode external trace is disabled, whether execution at privilege modes
+less than `M-mode` may be traced by an external debugger depends on the
+configuration held in `msdcfg.SDETRCALW`.
+
+When `msdcfg.SDETRCALW` = 0, external trace is disallowed for the SD. All trace
+output from the trace encoder module are disabled while the SD is active (the
+trace encoder must behave per `trTeEnable`=0).
+
+When `msdcfg.SDEDBGALW` = 1 then external trace of privilege modes less than
+`M-mode` is allowed for the SD, and programming of `trTeActive` and `trTeEnable`
+to 1 may transition the hart to enable trace for all privilege modes less than
+`M-mode`.
+
+==== `Smsdetrc`: interaction with external trace security controls (Informative)
+
+This section will be moved into the specification for external debug security.
+It is described in this specification as informational.
+
+The `metrcen` is an enable control for external race for the `M-mode` driven by
+an external trace module and is expected to be established by the RoT (following
+RISC-V security model recommendations SR_GEN_007 and 012). When privilege is
+`M-mode`, the `medbgtrc` gates the `trTEActive` control into the hart trace
+encoder and if 0, prevents the hart from generating any trace output.
+
+When `metrcen` is 0 and privilege is `M-mode`, `M-mode` activity cannot be
+traced and `M-mode` software can enforce that `trTeEnable` is set to the state
+of `msdcfg.SDETRCALW` for the SD it context switches the hart into.
+
+When `metrcen` is 1, there are no restrictions and all privilege modes
+(inclusive of `M-mode` and any SDs managed by the RDSM) are traceable.

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -100,10 +100,10 @@ to 1 may transition the hart to enable trace for all privilege modes less than
 This section will be moved into the specification for external debug security.
 It is described in this specification as informational.
 
-The `metrcen` is an enable control for external race for the `M-mode` driven by
+The `metrcen` is an enable control for external trace for the `M-mode` driven by
 an external trace module and is expected to be established by the RoT (following
 RISC-V security model recommendations SR_GEN_007 and 012). When privilege is
-`M-mode`, the `medbgtrc` gates the `trTEActive` control into the hart trace
+`M-mode`, the `metrcen` gates the `trTEActive` control into the hart trace
 encoder and if 0, prevents the hart from generating any trace output.
 
 When `metrcen` is 0 and privilege is `M-mode`, `M-mode` activity cannot be

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -47,7 +47,8 @@ When `msdcfg.sdedbgalw` is 0:
 
 
 When `msdcfg.sdedbgalw` = 1 then external debug of privilege modes less than
-`M-mode` is allowed for such a supervisor domain on a per-hart basis. +
+`M-mode` is allowed for such a supervisor domain on a per-hart basis, 
+with the additional requirements listed below. +
 
 To enforce the above controls specified by this extension, the following
 functional and security requirements must be met by the external secure debug
@@ -77,7 +78,8 @@ configuration held in `msdcfg.sdetrcalw`, as described below:
 When `msdcfg.sdetrcalw` = 0, external trace of the supervisor domain is disallowed.
 
 When `msdcfg.sdetrcalw` = 1 then external trace of privilege modes less than
-`M-mode` shall be allowed for the SD on a per hart basis.
+`M-mode` shall be allowed for the SD on a per hart basis, with the
+additional requirements listed below.
 
 To enforce the above controls specified by this extension, the following
 functional and security requirements must be met by the external secure debug

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -3,8 +3,12 @@
 == Supervisor Domain External Trace and Debug
 
 The <<MSDCFG>> CSR contains the `sdedbgalw` and `sdetrcalw` bits that control
-whether the current scheduled SD is allowed to be external-debugged or to be
-external-traced respectively.
+if the current scheduled SD is allowed to be external-debugged cite:[ExtDbg]
+or to be external-traced, respectively. External trace refers to tracing
+software running on a separate target RISC-V platform, via a trace control/data
+transport that provides external access to the trace encoder controls
+cite:[ETrc]. This extension only affects debug or trace orchestrated by an
+external actor. Self-hosted debug (and trace) are managed by the RDSM.
 
 === `Smsdedbg`: External Debug allowed control for Supervisor Domain
 
@@ -18,17 +22,21 @@ configuration held in `msdcfg.SDEDBGALW`.
 
 When `msdcfg.SDEDBGALW` = 0, external debug is disallowed for the SD. Abstract
 commands and halt request from the debug module are suppressed and stay pending
-while the SD is active.
+while the SD is active, on a per-hart basis. Other debug operations (current or
+defined in the future) must similarly be kept pending while the SD is active on
+a hart.
 
 When `msdcfg.SDEDBGALW` = 1 then external debug of privilege modes less than
-`M-mode` is allowed for the SD, and:
+`M-mode` is allowed for the SD on a per-hart basis, and:
 
-* A halt request may transition the hart to Debug Mode.
+* A valid request e.g. `haltreq` may transition the hart to Debug Mode. See
+other cases in RISC-V Debug specification cite:[ExtDbg].
 * Abstract commands and program buffer execution can access state of privilege
-modes less than `M-mode`.
+modes less than `M-mode`. In this context, "state" includes all resources
+accessible per the Debug specification cite:[ExtDbg].
 * Read and Write of `Sdtrig` and `Sdext` CSRs are allowed.
-* Debugger memory accesses occur with either `S-mode` or `U-mode` privilege (as
-if `aamvirtual` = 1 and `MPP` != `M-mode`).
+* Debugger memory accesses may occur with `S-mode` or `U-mode` privilege per
+software execution in the SD, and as if `aamvirtual` = 1 and `MPP` != `M-mode`.
 
 ==== `Smsdedbg` interaction with external debug security controls (Informative)
 
@@ -47,53 +55,59 @@ the hart from entering external debug mode.
 
 The following change is proposed to behavior of `M-mode` access to triggers with
 `dmode` = 1. This change allows the RDSM to remain in control of external debug
-for supervisor domains (unless the RDSM is itself under external debug).
+for supervisor domains (unless the RDSM is itself under external debug in which
+case this relaxation is a don't care condition).
 
 When `medbgen` is 0 and privilege is `M-mode`:
 
 * M-mode can read and write triggers, *including triggers with `dmode` = 1
 without restrictions*.
-* Abstract commands and halt request from external debugger stay pending while
-privilege is `M-mode`.
-* All trigger-matching is suppressed (similar to how `MIE` or `MTE` would
-suppress them)
+* Abstract commands and requests from an external debugger, that transition the
+hart into a halted state, stay pending while privilege is `M-mode` cite:[ExtDbg].
+* All trigger-matching is prevented from matching or firing, similar to how
+`MIE` or `MTE` would behave.
 
 When privilege is less than `M`, the OR of the `MSDCFG.sdedbgalw` and `medbgen`
 gates the `haltreq` from the debug module and the hart will enter Debug
 Mode if either is 1.
 
+[NOTE]
+====
 The configuration for `MSDCFG.sdedbgalw` may be obtained from the manifest/
-configuration of the supervisoer domain and should be managed by the M-mode root
+configuration of the supervisor domain and should be managed by the M-mode root
 security manager using secure memory.
+====
 
-When `medbgen` is 1, there are no restrictions. When `medbgen` is 0 but
-`MSDCFG.sdedbgalw` is 1, then the external debug mode may be entered but is
-restricted by `M-mode` software to prevent privileged CSR accesses and memory
-accesses by instructions executed in Debug Mode cannot use `M-mode`
-privilege. When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, the `M-mode`
-root domain security manager must not configure triggers with `action=1`.
-Triggers for the supervisor domain must be controlled by the root
-domain security manager to prevent any leakage of information across security
-domains.
+When `medbgen` is 1, there are no restrictions on external debug added by this
+specification.
+
+When `medbgen` is 0 but `MSDCFG.sdedbgalw` is 1, then the external debug mode
+may be entered but may be restricted by `M-mode` software by the setting of the
+`MSDCFG.sdedbgalw` control to prevent privileged CSR accesses, memory accesses
+by instructions executed, abstract commands in Debug Mode cannot use `M-mode`
+privilege.
+
+When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, triggers for the
+supervisor domain must be controlled by the root domain security manager to
+prevent any leakage of information across security domains. For example, RDSM
+should enforce triggers are programmed with `mcontrol.m` bit clear.
 
 === `Smsdetrc`: External Trace allowed control for Supervisor Domain
 
 When M-mode external trace is enabled, all supervisor domains activity may also
-be traced by an external debugger irrespective of the configuration held in
+be traced by an external trace tool irrespective of the configuration held in
 `msdcfg.SDETRCALW`.
 
 When M-mode external trace is disabled, whether execution at privilege modes
-less than `M-mode` may be traced by an external debugger depends on the
+less than `M-mode` may be traced by an external trace tool depends on the
 configuration held in `msdcfg.SDETRCALW`.
 
 When `msdcfg.SDETRCALW` = 0, external trace is disallowed for the SD. All trace
-output from the trace encoder module are disabled while the SD is active (the
-trace encoder must behave per `trTeEnable`=0).
+output from the trace encoder module are disabled while the SD is active on a
+per-hart basis.
 
 When `msdcfg.SDEDBGALW` = 1 then external trace of privilege modes less than
-`M-mode` is allowed for the SD, and programming of `trTeActive` and `trTeEnable`
-to 1 may transition the hart to enable trace for all privilege modes less than
-`M-mode`.
+`M-mode` shall be allowed for the SD on a per hart basis.
 
 ==== `Smsdetrc`: interaction with external trace security controls (Informative)
 
@@ -106,7 +120,7 @@ RISC-V security model recommendations SR_GEN_007 and 012). When privilege is
 `M-mode`, the `metrcen` gates the `halted` signal (from the hart) into the hart
 trace encoder. Per the Efficient trace specification cite:[Etrc], this side-band
 `halted` signal being asserted, stops subsequent tracing from the hart. On this
-signal being deasserted, the encode can start tracing again.
+signal being deasserted, the encoder can start tracing again.
 
 [NOTE]
 ====

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -60,8 +60,8 @@ privilege is `M-mode`.
 suppress them)
 
 When privilege is less than `M`, the OR of the `MSDCFG.sdedbgalw` and `medbgen`
-gates the `haltreq` from the debug module and the hart will enter external debug
-mode if either is 1.
+gates the `haltreq` from the debug module and the hart will enter Debug
+Mode if either is 1.
 
 The configuration for `MSDCFG.sdedbgalw` may be obtained from the manifest/
 configuration of the supervisoer domain and should be managed by the M-mode root
@@ -70,11 +70,11 @@ security manager using secure memory.
 When `medbgen` is 1, there are no restrictions. When `medbgen` is 0 but
 `MSDCFG.sdedbgalw` is 1, then the external debug mode may be entered but is
 restricted by `M-mode` software to prevent privileged CSR accesses and memory
-accesses by instructions executed in external debug mode cannot use `M-mode`
+accesses by instructions executed in Debug Mode cannot use `M-mode`
 privilege. When `medbgen` is 0 and `MSDCFG.sdedbgalw` is also 0, the `M-mode`
 root domain security manager must not configure triggers with `action=1`.
-Triggers for the supervisor domain are expected to be controlled by the root
-domain security manager to prevent any leakage of information.
+Triggers for the supervisor domain must be controlled by the root
+domain security manager to prevent any leakage of information across security domains.
 
 === `Smsdetrc`: External Trace allowed control for Supervisor Domain
 

--- a/chapter8.adoc
+++ b/chapter8.adoc
@@ -3,8 +3,8 @@
 == Supervisor Domain External Trace and Debug
 
 The <<MSDCFG>> CSR contains the `sdedbgalw` and `sdetrcalw` bits that control
-if the current scheduled SD is allowed to be external-debugged cite:[ExtDbg]
-or to be external-traced, respectively. External trace refers to tracing
+if the current scheduled SD is allowed to be external-debugged or to be
+external-traced cite:[ExtDbg], respectively. External trace refers to tracing
 software running on a separate target RISC-V platform, via a trace control/data
 transport that provides external access to the trace encoder controls
 cite:[ETrc]. This extension only affects debug or trace orchestrated by an

--- a/example.bib
+++ b/example.bib
@@ -23,3 +23,8 @@
   title = {RISC-V Debug Specification},
   url = {https://github.com/riscv/riscv-debug-spec}
 }
+
+@electronic{ETrc,
+  title = {RISC-V Efficient Trace for RISC-V, v2.0.2, March 5, 2024},
+  url = {https://github.com/riscv-non-isa/riscv-trace-spec/releases/download/v2.0.2/riscv-trace-spec-asciidoc.pdf}
+}

--- a/example.bib
+++ b/example.bib
@@ -29,6 +29,11 @@
   url = {https://github.com/riscv-non-isa/riscv-trace-spec/releases/download/v2.0.2/riscv-trace-spec-asciidoc.pdf}
 }
 
+@electronic{ExtDbgSec,
+  title = {RISC-V External Debug Security, v0.0, March 26, 2024},
+  url = {https://github.com/riscv-non-isa/riscv-external-debug-security/blob/main/external-debug-security.pdf}
+}
+
 @electronic{CBQRI,
   title = {RISC-V Capacity and Bandwidth Controller QoS Register Interface},
   url = {https://github.com/riscv-non-isa/riscv-cbqri}

--- a/header.adoc
+++ b/header.adoc
@@ -9,8 +9,8 @@
 :preface-title: Preamble
 :colophon:
 :appendix-caption: Appendix
-:imagesdir: images
-:title-logo-image: image:risc-v_logo.svg[pdfwidth=3.25in,align=center]
+:imagesdir: .
+:title-logo-image: image:images/risc-v_logo.svg[pdfwidth=3.25in,align=center]
 // Settings:
 :experimental:
 :reproducible:


### PR DESCRIPTION
add changes to Smsdedbg normative behavior per discussion in issue 26.
Also proposed changes to be documented in the Secure Ext debug spec to enable the behavior required for Smsdedbg. 