### PR TITLE
QC suggestions for RC1 (some minor clarifications)

### DIFF
--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -113,8 +113,7 @@ every bit position in the `SDID` field, then reading back the value in `mttp`
 to see which bit positions in the `SDID` field hold a one. The
 least-significant bits of `SDID` are implemented first: that is, if `SDIDLEN` >
 0, `SDID`[`SDIDLEN`-1:0] is writable. The maximal value of `SDIDLEN`, termed
-`SDIDMAX`, is 6 for `Smmtt[34 | 46 | 56]` and consequently allows for up to
-64 supervisor domains.
+`SDIDMAX`, is 6 for `Smmtt[34 | 46 | 56]`.
 
 The `mttp` register is considered active for the purposes of the physical
 address protection algorithm unless the effective privilege mode is `M`.

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -54,7 +54,7 @@ supervisor domains beyond the physical memory protection scheme described in
 Section 3.7 of the RISC-V privileged architecture specification cite:[ISA]. In
 this case, the remaining fields (`SDID`, `PPN`) in `mttp` must be set to
 zeros, else generate a fault. When `XLEN=32`, the other valid setting for
-`MODE` is `Smmtt34` to support allow/disallow and read-write-execute
+`MODE` is `Smmtt34` to support read-write-execute
 access permissions for 34-bit system physical addresses.
 
 When `XLEN=64`, other than `BARE`, the other valid settings for `MODE` are
@@ -113,7 +113,8 @@ every bit position in the `SDID` field, then reading back the value in `mttp`
 to see which bit positions in the `SDID` field hold a one. The
 least-significant bits of `SDID` are implemented first: that is, if `SDIDLEN` >
 0, `SDID`[`SDIDLEN`-1:0] is writable. The maximal value of `SDIDLEN`, termed
-`SDIDMAX`, is 6 for `Smmtt[34 | 46 | 56]`.
+`SDIDMAX`, is 6 for `Smmtt[34 | 46 | 56]` and consequently allows for up to
+64 supervisor domains.
 
 The `mttp` register is considered active for the purposes of the physical
 address protection algorithm unless the effective privilege mode is `M`.

--- a/chapter4.adoc
+++ b/chapter4.adoc
@@ -149,7 +149,7 @@ RV64 and <<mtt-l1-rv32>> for RV32.
 |`2M_PAGES` a|
 This encoding applies only to RV64.
 _The 32 MiB range of address space is partitioned into 16 2 MiB pages where each
-page has read/write/execute/access disallowed/not specified via the `INFO` field._
+page has read/write/execute access specified via the `INFO` field._
 The `INFO` field holds 16 2-bit `PERM` access-encoding for each 2 MiB address
 range to indicate: `no_access_allowed` (00b), `read-execute-allowed` (01b),
 `read-write-allowed` (10b), `read-write-execute-allowed` (11b). Bits
@@ -159,7 +159,7 @@ reserved and must be zero.
 |`4M_PAGES` a|
 This encoding applies only to RV32.
 _The 32 MiB range of address space is partitioned into 8 4 MiB pages where each
-page has read/write/execute/access disallowed/not specified via the `INFO` field._
+page has read/write/execute access specified via the `INFO` field._
 The `INFO` field holds 8 2-bit `PERM` access-encoding for each 4 MiB address
 range to indicate: `no_access_allowed` (00b), `read-execute-allowed` (01b),
 `read-write-allowed` (10b), `read-write-execute-allowed` (11b). Bits
@@ -347,8 +347,8 @@ batch optimized via the use of the sequence `SFENCE.W.INVAL`, `MINVAL.SPA` and
 
 [NOTE]
 ====
-Ongoing MTT lookups are not required to complete or terminate when `mttp` is 
-effectively disabled, unless a `MFENCE.SPA` instruction
+MTT lookups that began while `mttp` was active are not required to complete or
+terminate when `mttp` is no longer active, unless a `MFENCE.SPA` instruction
 matches the `SDID` (and optionally, `PADDR`) is executed. The `MFENCE.SPA`
 instruction must be used to ensure that updates to the `MTT` data structures are
 observed by subsequent implicit reads to those structures by a hart.

--- a/chapter4.adoc
+++ b/chapter4.adoc
@@ -149,7 +149,7 @@ RV64 and <<mtt-l1-rv32>> for RV32.
 |`2M_PAGES` a|
 This encoding applies only to RV64.
 _The 32 MiB range of address space is partitioned into 16 2 MiB pages where each
-page has read/write/execute access allowed/not specified via the `INFO` field._
+page has read/write/execute/access disallowed/not specified via the `INFO` field._
 The `INFO` field holds 16 2-bit `PERM` access-encoding for each 2 MiB address
 range to indicate: `no_access_allowed` (00b), `read-execute-allowed` (01b),
 `read-write-allowed` (10b), `read-write-execute-allowed` (11b). Bits
@@ -159,7 +159,7 @@ reserved and must be zero.
 |`4M_PAGES` a|
 This encoding applies only to RV32.
 _The 32 MiB range of address space is partitioned into 8 4 MiB pages where each
-page has read/write/execute access allowed/not specified via the `INFO` field._
+page has read/write/execute/access disallowed/not specified via the `INFO` field._
 The `INFO` field holds 8 2-bit `PERM` access-encoding for each 4 MiB address
 range to indicate: `no_access_allowed` (00b), `read-execute-allowed` (01b),
 `read-write-allowed` (10b), `read-write-execute-allowed` (11b). Bits
@@ -226,7 +226,7 @@ address space for the domain.
 === MTT access permissions lookup process
 
 MTT access-permissions for a physical address PA in the context of a
-supervisor domain is ascertained as follows:
+supervisor domain are ascertained as follows:
 
 1. Let _a_ be `mttp.ppn` x PAGESIZE, and let _i_ = LEVELS, where for mode
 `Smmtt34`, LEVELS = 2 and for `Smmtt[46 | 56]`, LEVELS = 3; PAGESIZE
@@ -302,10 +302,10 @@ implemented.
 
 MTT is checked for all accesses to physical memory, unless the effective privilege
 mode is M, including accesses that have undergone virtual to physical memory
-translation, but excluding MTT structure accesses. Data accesses in M-mode
-when the MPRV bit in mstatus is set and the MPP field in mstatus contains S
-or U are subject to MTT checks. MTT structure accesses are to be treated
-as implicit M-mode accesses and are subject to PMP/Smepmp and
+translation, but excluding MTT checker accesses to MTT structures. Data accesses
+in M-mode when the MPRV bit in mstatus is set and the MPP field in mstatus contains S
+or U are subject to MTT checks. MTT checker accesses to MTT structures are to be 
+treated as implicit M-mode accesses and are subject to PMP/Smepmp and
 IOPMP checks. The MTT checker indexes the MTT using the
 physical address of the access to lookup and enforce the access permissions.
 A mismatch of the access type and the access permissions specified in the
@@ -347,8 +347,8 @@ batch optimized via the use of the sequence `SFENCE.W.INVAL`, `MINVAL.SPA` and
 
 [NOTE]
 ====
-MTT lookups that began while `mttp` was active are not required to complete or
-terminate when `mttp` is no longer active, unless a `MFENCE.SPA` instruction
+Ongoing MTT lookups are not required to complete or terminate when `mttp` is 
+effectively disabled, unless a `MFENCE.SPA` instruction
 matches the `SDID` (and optionally, `PADDR`) is executed. The `MFENCE.SPA`
 instruction must be used to ensure that updates to the `MTT` data structures are
 observed by subsequent implicit reads to those structures by a hart.

--- a/chapter9.adoc
+++ b/chapter9.adoc
@@ -172,7 +172,7 @@ the `MCID` field.
 When the `srmcfg` CSR is read at privilege modes less than M, the value returned
 for the `RCID` and `MCID` fields of the register is computed as follows:
 
-.`RCID` and `MCID` read value compuation
+.`RCID` and `MCID` read value computation
 [listing]
 ----
 SRL_MASK = (1 << SRL) - 1


### PR DESCRIPTION
- Removal of "allow/disallow" only option from Smmtt34 
- adding explicit statement how many SDs are supported by SmMTT
- clarification that permission attribute is "disallowed" not allowed
- ambiguity: "MTT structure accesses" -> MTT checker accesses to MTT structures
- clarification to informative statement on MTT lookups in section 4.4:  Chapter 2 states that when Smmtt is implemented, MTT and e(PMP) are **always** active. Hence the phrases "while active / no longer active" can be misleading.

