### PR TITLE
Remove RULEID == 0 special case

### DIFF
--- a/chapter6.adoc
+++ b/chapter6.adoc
@@ -256,8 +256,7 @@ IO supervisor domain ID (`IOSDID`) and the MTT pointer (`MTTP`).
 
 The `OP` field is used to instruct IOMTTCHK to perform an operation listed in
 <<IOMTTCHK_OP>>. The `RULEID` is identifier of a rule in the SDCL function to
-operate on. The `RULEID` value of 0 indicates that the operation applies to all
-rules and is supported only if explicitly specified by an operation.
+operate on.
 
 [[IOMTTCHK_OP]]
 .I/O MTT checker operations (`OP`)


### PR DESCRIPTION
This special case does not apply to any of the defined operations.

Follow-up from issue #66.

Feel free to reject this if you think we should keep the special case for use by operations defined in the future.