### PR TITLE
Custom mode encodings

### DIFF
--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -82,11 +82,13 @@ specification cite:[ISA]. The remaining fields in `mmpt` (`SDID`, `PPN`) must be
 set to zeros.
 |1 |`Smmpt34` |Page-based memory protection for up to 34-bit physical address
 spaces.
-|2-3 |- |`_Reserved_`
+|2 |- |`_Reserved for future standard use._`
+|3 |- |`_Designated for custom use._` 
+
 |===
 
 .Encoding of `mmpt` `MODE` field for `XLEN=64`.
-[width="100%",cols="10%,14%,76%", options="header", id=mpt-64]
+[width="100%",cols="14%,14%,72%", options="header", id=mpt-64]
 |===
 |Value |Name |Description
 |0 |`Bare` | No page-based memory protection beyond the physical memory
@@ -99,7 +101,8 @@ spaces.
 spaces.
 |3 |`Smmpt64` |Page-based memory protection for up to 64-bit physical address
 spaces.
-|4-15 |- |`_Reserved_`
+|4-13 |- |`_Reserved for future standard use._`
+|14-15 |- |`_Designated for custom use._` 
 |===
 
 Implementations are not required to support all defined `MODE` settings. A write

--- a/chapter3.adoc
+++ b/chapter3.adoc
@@ -88,7 +88,7 @@ spaces.
 |===
 
 .Encoding of `mmpt` `MODE` field for `XLEN=64`.
-[width="100%",cols="14%,14%,72%", options="header", id=mpt-64]
+[width="100%",cols="10%,14%,76%", options="header", id=mpt-64]
 |===
 |Value |Name |Description
 |0 |`Bare` | No page-based memory protection beyond the physical memory


### PR DESCRIPTION
Providing entries for mmpt custom mode encodings for XLEN=32 (1 entry) and XL32=64 (2 entries).
As discussed during 4/22 Smmtt TG and CoVE TG meeting.
