### PR TITLE
Chapter4 - updated mpt-walk description + minor fixes

### DIFF
--- a/chapter4.adoc
+++ b/chapter4.adoc
@@ -80,13 +80,13 @@ MPTE entry in <<rv32-mpte-leaf>>.
 ....
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title="`Smmpt34` NAPOT leaf `MPTE`", id="rv32-mpte-leaf"]
+[title="`Smmpt34` NAPOT leaf `MPTE`", id="rv32-mpte-napot-leaf"]
 [wavedrom, ,svg]
 ....
 {reg: [
   {bits:  1,  name: 'V=1'},
   {bits:  1,  name: 'L=1'},
-  {bits:  1,  name: 'N=0'},
+  {bits:  1,  name: 'N=1'},
   {bits:  5,  name: 'Reserved'},
   {bits:  3,  name: 'XWR'},
   {bits:  1,  name: 'Reserved'},
@@ -131,15 +131,16 @@ When `MPTE.L`=1 and `MPTE.N`=1, the leaf `MPTE` represents a memory protection
 range that is part of a larger contiguous NAPOT memory protection range comprised
 of `2^(G+1)` MPTEs. All leaf MPTEs at that level of this NAPOT memory protection
 range have the same value for L, N, XWR and V bits. The encodings 0-5 and 7-15
-of `G` are reserved for Smmpt34.
+of `G` are reserved for Smmpt34. The format of a NAPOT leaf MPTE is shown in
+<<rv32-mpte-napot-leaf>>.
 
 [NOTE]
 ====
 The motivation of NAPOT MPTE is that access-type permissions for one or more
-entries representing the contigous region may be cached as a single cache entry
+entries representing the contiguous region may be cached as a single cache entry
 as if it were a single (large) page. This compaction can relieve access-type
 permission caches. The scheme allows an implementation to not take advantage of
-this property and simply cache the access-type permissions for pages seperately.
+this property and simply cache the access-type permissions for pages separately.
 
 The encoding of G=6 supports caching a single access-type permission entry
 representing a 4 MiB address range. Depending on need, the NAPOT scheme may be
@@ -149,7 +150,7 @@ accommodate other NAPOT sizes should that need arise.
 
 A non-leaf MPTE holds the PPN of the next level of the memory protection table.
 
-A leaf MPTE holds eight tuples of access type permisssion bits - one for each
+A leaf MPTE holds eight tuples of access type permission bits - one for each
 page in the range determined by that MPTE. Each tuple consists of 3 bits `XWR`,
 that provide the Execute (`X`), Write (`W`), and Read (`R`) permissions. The most
 significant 3 bits of the range offset identify a page in that range and are
@@ -160,7 +161,7 @@ used to identify the access type permission bits for an access to that page.
 [%autowidth,float="center",align="center",cols="^,^,^,<",options="header"]
 |===
 | X | W | R | Meaning
-| 0 | 0 | 0 | _Reserved for future use._
+| 0 | 0 | 0 | No access.
 | 0 | 0 | 1 | Read-only page.
 | 0 | 1 | 0 | _Reserved for future use._
 | 0 | 1 | 1 | Read-write page.
@@ -170,7 +171,7 @@ used to identify the access type permission bits for an access to that page.
 | 1 | 1 | 1 | Read-write-execute page.
 |===
 
-Access type permissions -- readable, writable, or executble -- are checked
+Access type permissions -- readable, writable, or executable -- are checked
 by MPT the same as for VS-stage and G-stage translation. For a memory access
 made to support VS-stage or G-stage address translation (such as a read/write to
 a VS-stage page table or a G-stage page table), permissions are checked as
@@ -195,9 +196,10 @@ follows:
    or PMP check, raise an access-fault exception corresponding to the original
    access type.
 
-3. If _mpte.v_=0, or if any bits or encodings that are reserved for future
-   standard use are set within _mpte_, stop and raise an access-fault exception
-   corresponding to the original access type.
+3. If _mpte.V_=0, or if any bits or encodings that are reserved for future
+   standard use are set within _mpte_, or if _mpte.L_ = 0 and _mpte.N_ = 1,
+   stop and raise an access-fault exception corresponding to the original 
+   access type.
 
 4. Otherwise, the _mpte_ is valid. If _mpte.L=1_ go to step 5; Otherwise, this
    MPTE is a pointer to the next level of the memory protection table. Let
@@ -205,13 +207,15 @@ follows:
    to the original access type. Otherwise, let _a_ = _mpte.PPN_ x PAGESIZE and
    go to step 2.
 
-5. If N=0, a non-NAPOT leaf _mpte_ has been found. If i > 0, the bits
-   _pa.pn[i-1]_ are included in the range offset, else for i = 0, the range
-   offset is specified in the _pa_. Let _pi_ be the value of the NUMPGINRANGE
-   most significant bits of the range offset (For Smmpt34, NUMPGINRANGE is 3).
-   Let _XWR=mpte.XWR[pi]_.
+5. If _mpte.N_=0, a non-NAPOT leaf _mpte_ has been found. If _i_ > 0, let _pi_
+   be the value of the NUMPGINRANGE most significant bits of _pa.pn[i-1]_.
+   Otherwise, for _i_ = 0, let _pi_ be the value of the NUMPGINRANGE most 
+   significant bits of the range offset specified in the _pa_.
+   (For Smmpt34, NUMPGINRANGE is 3). Let _XWR=mpte.XWR[pi]_.
 
-6. If N=1, a NAPOT leaf _mpte_ has been found. The _XWR=mpte.XWR_.
+6. If _mpte.N_=1, a NAPOT leaf _mpte_ has been found. Let _XWR=mpte.XWR_. If 
+   the value of _G_ is reserved for the current MPT mode, raise an access-fault 
+   exception corresponding to the original access type.
 
 7. Determine if the requested memory access is allowed by the _XWR_ bits, given
    the effective privilege mode and MXR field of the `mstatus` register. If not,
@@ -265,7 +269,8 @@ The physical page number of the root memory protection table is stored in the
 `mmpt` register's PPN field.
 
 The format of a non-leaf MPTE entry is shown in <<rv64-mpte>> and that of a leaf
-MPTE entry in <<rv64-mpte-leaf>>.
+MPTE entry in <<rv64-mpte-leaf>>. The format of a NAPOT leaf MPTE is shown
+in <<rv64-mpte-napot-leaf>>.
 
 A leaf MPTE provides access type permissions for sixteen pages in the address
 range determined by that MPTE.
@@ -314,13 +319,13 @@ range determined by that MPTE.
 ....
 
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title="Smmpt43 NAPOT leaf `MPTE` entry", id="rv64-mpte-leaf"]
+[title="Smmpt43 NAPOT leaf `MPTE` entry", id="rv64-mpte-napot-leaf"]
 [wavedrom, ,svg]
 ....
 {reg: [
   {bits:   1, name: 'V'},
   {bits:   1, name: 'L=1'},
-  {bits:   1, name: 'N=0'},
+  {bits:   1, name: 'N=1'},
   {bits:   5, name: 'Reserved'},
   {bits:   3, name: 'XWR'},
   {bits:   1, name: '0'},
@@ -342,7 +347,7 @@ The encodings 0-3 and 5-15 of `G` are reserved for Smmpt43.
 [NOTE]
 ====
 The encoding of G=4 supports caching a single access-type permission entry
-representing a 2 MiB or a 1 GiB address range. These contigous address range
+representing a 2 MiB or a 1 GiB address range. These contiguous address range
 sizes represent large/huge page sizes used commonly by memory allocators.
 
 Depending on need, the NAPOT scheme may be extended to other page sizes in


### PR DESCRIPTION
- Fixed figures 8, 12: N=1
- added references to above figures
- MPT lookup process:
  - step 2: update to account for removal of non-leaf NAPOT
  - step 5: "inclusion in range offset for i>0" gives room for ambiguity. Propose explicit description of MSB bits selection.
  - step 6: Add error case for invalid G encodings.
- callout "No access" for XWR encoding "000". Reason: current description "Reserved for future use" implies that this encoding may be used for other purposes in future, which could break backward-compatibility for implementations using it as _no access._
- a few typos