### PR TITLE
Fix MPTINVAL ordering on MPT mode/PPN change

### DIFF
--- a/chapter6.adoc
+++ b/chapter6.adoc
@@ -962,7 +962,7 @@ may use the `IOFENCE` operation after updating the configurations. Successful
 completion of an `IOFENCE` operation also guarantees that the I/O MPT Checker
 has observed all configuration updates made prior to the `IOFENCE`. If the
 configuration updates modify the MPT mode and/or PPN, an `MPTINVAL` operation
-with `PPNV` set to 0 must be issued before the `IOFENCE`.
+with `PPNV` set to 0 must be issued after the `IOFENCE`.
 
 === Treatment of Device-Side Address Translation Caches
 


### PR DESCRIPTION
The `MPTINVAL` on an MPT mode/PPN change has to come after the `IOFENCE`, not before.

Before the fence the new configuration need not have been observed yet, so a request can still be checked against the old MPT and cache an entry that outlives the fence. Nothing later invalidates it.

Reference: https://github.com/riscv/riscv-smmtt/pull/300#issuecomment-5268010350
